### PR TITLE
add links to deny(warnings) antipattern, fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ language.
 * TODO wildcard matches
 * TODO taking an enum rather than having multiple functions
 * TODO `unwrap()`ing every `Result` instead of forwarding it
-
+* [`#[deny(warnings)]`](anti_patterns/deny-warnings.md)
 
 
 ## Contributing

--- a/anti_patterns/deny-warnings.md
+++ b/anti_patterns/deny-warnings.md
@@ -45,7 +45,7 @@ explicitly.
 
 The following command line will build with all warnings set to `deny`:
  
-```RUSTFLAGS="-D warnings" cargo build"```
+```RUSTFLAGS="-D warnings" cargo build```
 
 This can be done by any individual developer (or be set in a CI tool like
 Travis, but remember that this may break the build when something changes)


### PR DESCRIPTION
It appears the README update got lost from my last PR. Also I spotted a typo, which I fix here.