### PR TITLE
Update ctor.md

### DIFF
--- a/idioms/ctor.md
+++ b/idioms/ctor.md
@@ -1,4 +1,4 @@
-# Contructors
+# Constructors
 
 ## Description
 


### PR DESCRIPTION
Tiny spelling correction - missing 's' in the "Constructors" word