### PR TITLE
Show call of default()

### DIFF
--- a/idioms/default.md
+++ b/idioms/default.md
@@ -36,6 +36,12 @@ struct MyConfiguration {
 impl MyConfiguration {
     // add setters here
 }
+
+fn main() {
+    // construct a new instance with default values
+    let mut conf = MyConfiguration::default();
+    // do somthing with conf here
+}
 ```
 
 ## See also


### PR DESCRIPTION
The code lacks an example call with ```default()```. It might not be completely clear to a Rust beginner, what the ```#[derive(Default)]``` actually enabled.