### PR TITLE
Fix default idiom example

### DIFF
--- a/idioms/default.md
+++ b/idioms/default.md
@@ -44,7 +44,7 @@ fn main() {
     let mut conf = MyConfiguration::default();
     // do something with conf here
     conf.check = true;
-    eprintln!("conf = {:#?}", conf);
+    println!("conf = {:#?}", conf);
 }
 ```
 

--- a/idioms/default.md
+++ b/idioms/default.md
@@ -19,9 +19,7 @@ different names, but there can only be one `Default` implementation per type.
 
 ## Example
 
-```rust,ignore
-// note that we can simply auto-derive Default here.
-#[derive(Default)]
+```rust
 use std::{path::PathBuf, time::Duration};
 
 // note that we can simply auto-derive Default here.

--- a/idioms/default.md
+++ b/idioms/default.md
@@ -22,11 +22,15 @@ different names, but there can only be one `Default` implementation per type.
 ```rust,ignore
 // note that we can simply auto-derive Default here.
 #[derive(Default)]
+use std::{path::PathBuf, time::Duration};
+
+// note that we can simply auto-derive Default here.
+#[derive(Default, Debug)]
 struct MyConfiguration {
     // Option defaults to None
-    output: Option<Path>,
-    // Vecs default to empty vector
-    search_path: Vec<Path>,
+    output: Option<PathBuf>,
+    // // Vecs default to empty vector
+    search_path: Vec<PathBuf>,
     // Duration defaults to zero time
     timeout: Duration,
     // bool defaults to false
@@ -41,6 +45,8 @@ fn main() {
     // construct a new instance with default values
     let mut conf = MyConfiguration::default();
     // do somthing with conf here
+    conf.check = true;
+    eprintln!("conf = {:#?}", conf);
 }
 ```
 

--- a/idioms/default.md
+++ b/idioms/default.md
@@ -29,7 +29,7 @@ use std::{path::PathBuf, time::Duration};
 struct MyConfiguration {
     // Option defaults to None
     output: Option<PathBuf>,
-    // // Vecs default to empty vector
+    // Vecs default to empty vector
     search_path: Vec<PathBuf>,
     // Duration defaults to zero time
     timeout: Duration,

--- a/idioms/default.md
+++ b/idioms/default.md
@@ -44,7 +44,7 @@ impl MyConfiguration {
 fn main() {
     // construct a new instance with default values
     let mut conf = MyConfiguration::default();
-    // do somthing with conf here
+    // do something with conf here
     conf.check = true;
     eprintln!("conf = {:#?}", conf);
 }


### PR DESCRIPTION
Before this change,

the example code doesn't run on the current rust stable release(1.49).

This is because `Path` inherently has a u8 that requires the sized trait which requires either statics or replacing Path with PathBuf.

After this change,

The example code will run "as-is" without warnings or errors.