### PR TITLE
Update compose structs compile error example for NLL

### DIFF
--- a/patterns/compose-structs.md
+++ b/patterns/compose-structs.md
@@ -31,10 +31,11 @@ fn foo(a: &mut A) -> &u32 { &a.f2 }
 fn bar(a: &mut A) -> u32 { a.f1 + a.f3 }
 
 fn baz(a: &mut A) {
-    // x causes a to be borrowed for the rest of the function.
+    // The later usage of x causes a to be borrowed for the rest of the function.
     let x = foo(a);
     // Borrow check error
     let y = bar(a); //~ ERROR: cannot borrow `*a` as mutable more than once at a time
+    println!("{}", x);
 }
 ```
 
@@ -63,6 +64,7 @@ fn baz(a: &mut A) {
     let x = foo(&mut a.b);
     // Now it's OK!
     let y = bar(&mut a.c);
+    println!("{}", x);
 }
 ```
 

--- a/patterns/compose-structs.md
+++ b/patterns/compose-structs.md
@@ -34,7 +34,7 @@ fn baz(a: &mut A) {
     // The later usage of x causes a to be borrowed for the rest of the function.
     let x = foo(a);
     // Borrow checker error:
-    // let y = bar(a); ~ ERROR: cannot borrow `*a` as mutable more than once at a time
+    // let y = bar(a); // ~ ERROR: cannot borrow `*a` as mutable more than once at a time
     println!("{}", x);
 }
 ```

--- a/patterns/compose-structs.md
+++ b/patterns/compose-structs.md
@@ -20,7 +20,7 @@ pattern often reveals smaller units of functionality.
 Here is a contrived example of where the borrow checker foils us in our plan to
 use a struct:
 
-```rust,ignore
+```rust
 struct A {
     f1: u32,
     f2: u32,
@@ -33,8 +33,8 @@ fn bar(a: &mut A) -> u32 { a.f1 + a.f3 }
 fn baz(a: &mut A) {
     // The later usage of x causes a to be borrowed for the rest of the function.
     let x = foo(a);
-    // Borrow check error
-    let y = bar(a); //~ ERROR: cannot borrow `*a` as mutable more than once at a time
+    // Borrow checker error:
+    // let y = bar(a); ~ ERROR: cannot borrow `*a` as mutable more than once at a time
     println!("{}", x);
 }
 ```


### PR DESCRIPTION
The first example in https://rust-unofficial.github.io/patterns/patterns/compose-structs.html states that there will be a compile error but this is not true with non lexical lifetimes.