### PR TITLE
Fix on-stack dispatch example

### DIFF
--- a/idioms/on-stack-dyn-dispatch.md
+++ b/idioms/on-stack-dyn-dispatch.md
@@ -16,7 +16,7 @@ std::io::File;
 let (mut stdin_read, mut file_read);
 
 // We need to ascribe the type to get dynamic dispatch.
-let readable: &mut dyn io::Read = if arg == '-' {
+let readable: &mut dyn io::Read = if arg == "-" {
     stdin_read = io::stdin();
     &mut stdin_read
 } else {

--- a/idioms/on-stack-dyn-dispatch.md
+++ b/idioms/on-stack-dyn-dispatch.md
@@ -9,8 +9,12 @@ below:
 
 ## Example
 
-```rust,ignore
-std::io::File;
+```rust
+use std::io;
+use std::fs;
+
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+# let arg = "-";
 
 // These must live longer than `readable`, and thus are declared first:
 let (mut stdin_read, mut file_read);
@@ -25,6 +29,9 @@ let readable: &mut dyn io::Read = if arg == "-" {
 };
 
 // Read from `readable` here.
+
+# Ok(())
+# }
 ```
 
 ## Motivation


### PR DESCRIPTION
* A `char` can't be used as a path. The correct `"-"` is already used in the "Disadvantages" example.
* Removed the `ignore` from the code block.