### PR TITLE
Add link to derive_more for newtypes

### DIFF
--- a/patterns/newtype.md
+++ b/patterns/newtype.md
@@ -102,3 +102,5 @@ Here, `Bar` might be some public, generic type and `T1` and `T2` are some intern
 [Newtypes in Haskell](https://wiki.haskell.org/Newtype)
 
 [Type aliases](https://doc.rust-lang.org/stable/book/ch19-04-advanced-types.html#creating-type-synonyms-with-type-aliases)
+
+[derive_more](https://crates.io/crates/derive_more), a crate for deriving many builtin traits on newtypes.


### PR DESCRIPTION
I think derive_more is one of the most helpful crates for mitigating the downsides of the newtype pattern.