### PR TITLE
Use a problem as the intro for newtype pattern

### DIFF
--- a/patterns/newtype.md
+++ b/patterns/newtype.md
@@ -1,8 +1,11 @@
 # Newtype
 
-Rust has strong static types. This can be very different than what you are used to if you are coming from a loosely-typed language. Don't worry, though. Once you get used to them, you'll find the types actually make your life easier. Why? Because you are making implicit assumptions explicit.
+What if in some cases we want a type to behave similar to another type but
+still different? What if we want to enforce some behavior at compile time
+which using only type aliases is not enough? For example, have a custom
+`Display` implementation for `String` for security reasons (password).
 
-A really convenient application of the Rust type system is the Newtype pattern.
+We could use the newtype pattern to provide type safety and encapsulation.
 
 ## Description
 
@@ -97,6 +100,7 @@ Here, `Bar` might be some public, generic type and `T1` and `T2` are some intern
 
 ## See also
 
+- [Advanced Types in the book](https://doc.rust-lang.org/book/ch19-04-advanced-types.html?highlight=newtype#using-the-newtype-pattern-for-type-safety-and-abstraction)
 - [Newtypes in the style guide](https://doc.rust-lang.org/1.0.0/style/features/types/newtype.html)
 - [Newtypes in Haskell](https://wiki.haskell.org/Newtype)
 - [Type aliases](https://doc.rust-lang.org/stable/book/ch19-04-advanced-types.html#creating-type-synonyms-with-type-aliases)

--- a/patterns/newtype.md
+++ b/patterns/newtype.md
@@ -101,7 +101,6 @@ Here, `Bar` might be some public, generic type and `T1` and `T2` are some intern
 ## See also
 
 - [Advanced Types in the book](https://doc.rust-lang.org/book/ch19-04-advanced-types.html?highlight=newtype#using-the-newtype-pattern-for-type-safety-and-abstraction)
-- [Newtypes in the style guide](https://doc.rust-lang.org/1.0.0/style/features/types/newtype.html)
 - [Newtypes in Haskell](https://wiki.haskell.org/Newtype)
 - [Type aliases](https://doc.rust-lang.org/stable/book/ch19-04-advanced-types.html#creating-type-synonyms-with-type-aliases)
 - [derive_more](https://crates.io/crates/derive_more), a crate for deriving many builtin traits on newtypes.

--- a/patterns/newtype.md
+++ b/patterns/newtype.md
@@ -4,7 +4,7 @@ What if in some cases we want a type to behave similar to another type or
 enforce some behaviour at compile time where using only type aliases would 
 not be enough? 
 
-For example, if you want to create a custom `Display` implementation for `String` 
+For example, if we want to create a custom `Display` implementation for `String` 
 due to security considerations (e.g. passwords).
 
 For such cases we could use the `Newtype` pattern to provide __type safety__ and __encapsulation__.

--- a/patterns/newtype.md
+++ b/patterns/newtype.md
@@ -1,9 +1,11 @@
 # Newtype
 
-What if in some cases we want a type to behave similar to another type but
-still different? What if we want to enforce some behavior at compile time
-which using only type aliases is not enough? For example, have a custom
-`Display` implementation for `String` for security reasons (password).
+What if in some cases we want a type to behave similar to another type or 
+enforce some behaviour at compile time where using only type aliases would 
+not be enough? 
+
+For example, if you want to create a custom `Display` implementation for `String` 
+due to security considerations (e.g. passwords).
 
 We could use the newtype pattern to provide type safety and encapsulation.
 

--- a/patterns/newtype.md
+++ b/patterns/newtype.md
@@ -7,7 +7,7 @@ not be enough?
 For example, if you want to create a custom `Display` implementation for `String` 
 due to security considerations (e.g. passwords).
 
-We could use the newtype pattern to provide type safety and encapsulation.
+For such cases we could use the `Newtype` pattern to provide __type safety__ and __encapsulation__.
 
 ## Description
 


### PR DESCRIPTION
A problem can highlight some of the use cases of newtype
pattern rather than discussing generally that rust is strongly
typed. Make the user understand the need of newtype.

I wonder if it should be in the description instead?

Continued https://github.com/rust-unofficial/patterns/pull/117

r? @simonsan 