### PR TITLE
contributing: add markdown lints

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,8 @@ code examples are correct.
 
 ### Markdown lint
 
-To make sure the files comply with our Markdown style we use [markdownlint-cli](https://github.com/igorshubovych/markdownlint-cli). To spare you some manual work to get through the CI test you can use the following commands to automatically fix most of the emerging problems when writing Markdown files.
+To make sure the files comply with our Markdown style we use [markdownlint-cli](https://github.com/igorshubovych/markdownlint-cli). 
+To spare you some manual work to get through the CI test you can use the following commands to automatically fix most of the emerging problems when writing Markdown files.
 
 - Install:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ code examples are correct.
 
 ### Markdown lint
 
-We use [markdownlint-cli](https://github.com/igorshubovych/markdownlint-cli) to check we write correct markdown files.
+To make sure the files comply with our Markdown style we use [markdownlint-cli](https://github.com/igorshubovych/markdownlint-cli). To spare you some manual work to get through the CI test you can use the following commands to automatically fix most of the emerging problems when writing Markdown files.
 
 - Install:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,16 +40,7 @@ Don't forget to add your new article to the `SUMMARY.md` to let it be rendered t
 
 Please make `Draft Pull requests` early so we can follow your progress and can give early feedback (see the following section).
 
-## Creating a Pull Request
-
-"Release early and often!" also applies to pull requests!
-
-Once your article has some visible work, create a `[WIP]` draft pull request and give it a description of what you did or want to do.
-Early reviews of the community are not meant as an offense but to give feedback.
-
-A good principle: "Work together, share ideas, teach others."
-
-## Test the book locally before submitting
+## Check the article locally
 
 Before submitting the PR launch the commands `mdbook build` to make sure that the book builds and `mdbook test` to make sure that
 code examples are correct.
@@ -71,6 +62,15 @@ To make sure the files comply with our Markdown style we use [markdownlint-cli](
 - Automatically fix basic errors:
   - unix: `markdownlint -f '**/*.md'`
   - windows: `markdownlint -f **/*.md`
+
+## Creating a Pull Request
+
+"Release early and often!" also applies to pull requests!
+
+Once your article has some visible work, create a `[WIP]` draft pull request and give it a description of what you did or want to do.
+Early reviews of the community are not meant as an offense but to give feedback.
+
+A good principle: "Work together, share ideas, teach others."
 
 ### Important Note
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,10 +49,28 @@ Early reviews of the community are not meant as an offense but to give feedback.
 
 A good principle: "Work together, share ideas, teach others."
 
-### Test the book locally before submitting
+## Test the book locally before submitting
 
 Before submitting the PR launch the commands `mdbook build` to make sure that the book builds and `mdbook test` to make sure that
 code examples are correct.
+
+### Markdown lint
+
+We use [markdownlint-cli](https://github.com/igorshubovych/markdownlint-cli) to check we write correct markdown files.
+
+- Install:
+
+  ```sh
+  npm install -g markdownlint-cli
+  ```
+
+- Check all markdown files:
+  - unix: `markdownlint '**/*.md'`
+  - windows: `markdownlint **/*.md`
+
+- Automatically fix basic errors:
+  - unix: `markdownlint -f '**/*.md'`
+  - windows: `markdownlint -f **/*.md`
 
 ### Important Note
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ code examples are correct.
 
 ### Markdown lint
 
-To make sure the files comply with our Markdown style we use [markdownlint-cli](https://github.com/igorshubovych/markdownlint-cli). 
+To make sure the files comply with our Markdown style we use [markdownlint-cli](https://github.com/igorshubovych/markdownlint-cli).
 To spare you some manual work to get through the CI test you can use the following commands to automatically fix most of the emerging problems when writing Markdown files.
 
 - Install:


### PR DESCRIPTION
Closes #167

For me `markdownlint '**/*.md'` matches also markdown files in the current directory. No need to also do `markdownlint '*.md'`
Tell me if it works for you.

This works for the github action, too. See #174