### PR TITLE
ci: simplify lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,11 +46,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - name: Lint all files in current directory
-        uses: avto-dev/markdown-lint@v1
-        with:
-          config: '.markdownlint.yaml' 
-          args: '*.md'
       - name: Lint all files recursively
         uses: avto-dev/markdown-lint@v1
         with:


### PR DESCRIPTION
I tried this in my [fork](https://github.com/MarcoIeni/patterns/commit/a1584ede200f37405f3026fc149bec52c259958a) and as you can see it is detecting an error in the CONTRIBUTING.md file, which is in the top directory.

FYI @Takashiidobe 