### PR TITLE
MDlint: Do not allow tabs in code blocks (again)

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,5 +1,3 @@
 ---
-MD010:
-  code_blocks: false
 MD013:
   line_length: 300


### PR DESCRIPTION
Remove again rule exception removed in #178 but introduced by mistake again by #176