### PR TITLE
Talk about mem::take instead of mem::replace

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -8,7 +8,7 @@
   - [The `Default` Trait](./idioms/default.md)
   - [Collections Are Smart Pointers](./idioms/deref.md)
   - [Finalisation in Destructors](./idioms/dtor-finally.md)
-  - [`mem::replace(_)`](./idioms/mem-replace.md)
+  - [`mem::{take(_), replace(_)}`](./idioms/mem-replace.md)
   - [On-Stack Dynamic Dispatch](./idioms/on-stack-dyn-dispatch.md)
   - [Foreign function interface usage](./idioms/ffi-intro.md)
     - [Idiomatic Errors](./idioms/ffi-errors.md)

--- a/idioms/mem-replace.md
+++ b/idioms/mem-replace.md
@@ -38,7 +38,7 @@ fn a_to_b(e: &mut MyEnum) {
 
 This also works with more variants:
 
-```Rust
+```rust
 use std::mem;
 
 enum MultiVariateEnum {
@@ -49,7 +49,7 @@ enum MultiVariateEnum {
 }
 
 fn swizzle(e: &mut MultiVariateEnum) {
-    use self::MultiVariateEnum::*;
+    use MultiVariateEnum::*;
     *e = match *e {
         // Ownership rules do not allow taking `name` by value, but we cannot
         // take the value out of a mutable reference, unless we replace it:

--- a/idioms/mem-replace.md
+++ b/idioms/mem-replace.md
@@ -99,7 +99,7 @@ borrow checker. The compiler may fail to optimize away the double store,
 resulting in reduced performance as opposed to what you'd do in unsafe
 languages.
 
-The type you are taking needs to implement the `Default` trait.
+The type you are taking needs to implement the [`Default` trait](./default.md).
 However, if the type you're working with doesn't implement this, you
 can instead use `mem::replace`.
 

--- a/idioms/mem-replace.md
+++ b/idioms/mem-replace.md
@@ -1,4 +1,4 @@
-# `mem::take` to keep owned values in changed enums
+# `mem::{take(_), replace(_)}` to keep owned values in changed enums
 
 ## Description
 

--- a/idioms/mem-replace.md
+++ b/idioms/mem-replace.md
@@ -99,6 +99,10 @@ borrow checker. The compiler may fail to optimize away the double store,
 resulting in reduced performance as opposed to what you'd do in unsafe
 languages.
 
+The type you are taking needs to implement the `Default` trait.
+However, if the type you're working with doesn't implement this, you
+can instead use `mem::replace`.
+
 ## Discussion
 
 This pattern is only of interest in Rust. In GC'd languages, you'd take the

--- a/idioms/mem-replace.md
+++ b/idioms/mem-replace.md
@@ -80,6 +80,10 @@ and returning the previous value. For `String`, the default value is an empty
 `String`, which does not need to allocate. As a result, we get the original
 `name` *as an owned value*. We can then wrap this in another enum.
 
+`mem::replace` is very similar, but allows us to specify what to
+replace the value with. An equivalent to our `mem::take` line would be
+`mem::replace(name, String::new())`.
+
 Note, however, that if we are using an `Option` and want to replace its
 value with a `None`, `Option`’s `take()` method provides a shorter and
 more idiomatic alternative.

--- a/idioms/mem-replace.md
+++ b/idioms/mem-replace.md
@@ -99,9 +99,9 @@ borrow checker. The compiler may fail to optimize away the double store,
 resulting in reduced performance as opposed to what you'd do in unsafe
 languages.
 
-The type you are taking needs to implement the [`Default` trait](./default.md).
-However, if the type you're working with doesn't implement this, you
-can instead use `mem::replace`.
+Furthermore, the type you are taking needs to implement the [`Default`
+trait](./default.md). However, if the type you're working with doesn't
+implement this, you can instead use `mem::replace`.
 
 ## Discussion
 

--- a/idioms/mem-replace.md
+++ b/idioms/mem-replace.md
@@ -80,7 +80,7 @@ and returning the previous value. For `String`, the default value is an empty
 `String`, which does not need to allocate. As a result, we get the original
 `name` *as an owned value*. We can then wrap this in another enum.
 
-`mem::replace` is very similar, but allows us to specify what to
+__NOTE:__ `mem::replace` is very similar, but allows us to specify what to
 replace the value with. An equivalent to our `mem::take` line would be
 `mem::replace(name, String::new())`.
 


### PR DESCRIPTION
The motive behind this PR is that mem::take is often neater and more elegant than mem::replace, especially in the example listed in the original mem::replace article.

This PR changes the mem::replace article to instead focus on mem::take. The article does mention mem::replace as an alternative if you don't want the default value to be the `src`, or if your type doesn't implement `Default`.

This also fixes a typo in the source code block that prevented the block from being compiled and executed, and then fixes a compile error in the block itself.

EDIT of Maintainer: Closes #96 