### PR TITLE
choose different language in some parts

### DIFF
--- a/idioms/rustdoc-init.md
+++ b/idioms/rustdoc-init.md
@@ -2,8 +2,9 @@
 
 ## Description
 
-If a struct takes significant effort to initialize, when writing docs, it can be quicker to wrap your example with a
-function which takes the struct as an argument.
+If a struct takes significant effort to initialize, when writing docs, it can be
+quicker to wrap your example with a helper function which takes the struct as an
+argument.
 
 ## Motivation
 
@@ -43,8 +44,9 @@ impl Connection {
 
 ## Example
 
-Instead of typing all of this boiler plate to create an `Connection` and `Request` it is easier to just
-create a wrapping dummy function which takes them as arguments:
+Instead of typing all of this boiler plate to create an `Connection` and
+`Request` it is easier to just create a wrapping helper function which takes
+them as arguments:
 
 ```rust,ignore
 struct Connection {
@@ -84,6 +86,7 @@ So this pattern is most useful when need `no_run`. With this, you do not need to
 
 If assertions are not required this pattern works well.
 
-If they are, an alternative can be to create a public method to create a dummy instance which is annotated
-with `#[doc(hidden)]` (so that users won't see it).
-Then this method can be called inside of rustdoc because it is part of the crate's public API.
+If they are, an alternative can be to create a public method to create a helper
+instance which is annotated with `#[doc(hidden)]` (so that users won't see it).
+Then this method can be called inside of rustdoc because it is part of the
+crate's public API.

--- a/patterns/index.md
+++ b/patterns/index.md
@@ -1,11 +1,11 @@
 # Design Patterns
 
-[Design patterns](https://en.wikipedia.org/wiki/Software_design_pattern) are "general reusable
-solutions to a commonly occurring problem within a given context in software design".
-Design patterns are a great way to describe some of the culture and 'tribal knowledge'
-of programming in a language.
-Design patterns are very language-specific - what is a pattern in one language may be
-unnecessary in another due to a language feature, or impossible to express due to a missing feature.
+[Design patterns](https://en.wikipedia.org/wiki/Software_design_pattern) are
+"general reusable solutions to a commonly occurring problem within a given
+context in software design". Design patterns are a great way to describe the
+culture of a programming language. Design patterns are very language-specific -
+what is a pattern in one language may be unnecessary in another due to a
+language feature, or impossible to express due to a missing feature.
 
 If overused, design patterns can add unnecessary complexity to programs.
 However, they are a great way to share intermediate and advanced level knowledge about a programming language.


### PR DESCRIPTION
This PR chooses different language in two different places. It
substitutes `dummy function` for `helper function`. It removes
`tribal knowledge` and rewords the sentence. Edited paragraphs have been
constrained to a width of 80 characters in line with the Rust style
guide.

Other instances of what I personally considered to be "dodgy" language
were ignored due to having precedent in computer science idioms, having
precedent as a Rust-specific feature (`fat pointers`), or another
reason.

The inciting incident for this PR was [this
comment](https://github.com/rust-unofficial/patterns/issues/199#issuecomment-760271389).

Signed-off-by: Cassandra McCarthy <cassie@7596ff.com>
