### PR TITLE
Improve mem-replace examples

### DIFF
--- a/idioms/mem-replace.md
+++ b/idioms/mem-replace.md
@@ -19,20 +19,13 @@ enum MyEnum {
 }
 
 fn a_to_b(e: &mut MyEnum) {
-
-    // we mutably borrow `e` here. This precludes us from changing it directly
-    // as in `*e = ...`, because the borrow checker won't allow it. Therefore
-    // the assignment to `e` must be outside the `if let` clause.
-    *e = if let MyEnum::A { ref mut name, x: 0 } = *e {
-
+    if let MyEnum::A { name, x: 0 } = e {
         // this takes out our `name` and put in an empty String instead
         // (note that empty strings don't allocate).
         // Then, construct the new enum variant (which will
-        // be assigned to `*e`, because it is the result of the `if let` expression).
-        MyEnum::B { name: mem::take(name) }
-
-    // In all other cases, we return immediately, thus skipping the assignment
-    } else { return }
+        // be assigned to `*e`
+        *e = MyEnum::B { name: mem::take(name) }
+    }
 }
 ```
 
@@ -50,11 +43,11 @@ enum MultiVariateEnum {
 
 fn swizzle(e: &mut MultiVariateEnum) {
     use MultiVariateEnum::*;
-    *e = match *e {
+    *e = match e {
         // Ownership rules do not allow taking `name` by value, but we cannot
         // take the value out of a mutable reference, unless we replace it:
-        A { ref mut name } => B { name: mem::take(name) },
-        B { ref mut name } => A { name: mem::take(name) },
+        A { name } => B { name: mem::take(name) },
+        B { name } => A { name: mem::take(name) },
         C => D,
         D => C
     }

--- a/idioms/mem-replace.md
+++ b/idioms/mem-replace.md
@@ -23,7 +23,7 @@ fn a_to_b(e: &mut MyEnum) {
         // this takes out our `name` and put in an empty String instead
         // (note that empty strings don't allocate).
         // Then, construct the new enum variant (which will
-        // be assigned to `*e`
+        // be assigned to `*e`).
         *e = MyEnum::B { name: mem::take(name) }
     }
 }


### PR DESCRIPTION
Before:

```rust
fn a_to_b(e: &mut MyEnum) {
    *e = if let MyEnum::A { ref mut name, x: 0 } = *e {
        MyEnum::B { name: mem::take(name) }
    } else { return }
}
```

After:
```rust
fn a_to_b(e: &mut MyEnum) {
    if let MyEnum::A { name, x: 0 } = e {
        *e = MyEnum::B { name: mem::take(name) }
    }
}
```