### PR TITLE
Fix internal links

### DIFF
--- a/idioms/mem-replace.md
+++ b/idioms/mem-replace.md
@@ -65,8 +65,8 @@ change the value (as in the example above).
 The borrow checker won't allow us to take out `name` of the enum (because
 *something* must be there. We could of course `.clone()` name and put the clone
 into our `MyEnum::B`, but that would be an instance of the [Clone to satisfy
-the borrow checker] antipattern. Anyway, we can avoid the extra allocation by
-changing `e` with only a mutable borrow.
+the borrow checker](../anti_patterns/borrow_clone.md) antipattern. Anyway, we
+can avoid the extra allocation by changing `e` with only a mutable borrow.
 
 `mem::take` lets us swap out the value, replacing it with it's default value,
 and returning the previous value. For `String`, the default value is an empty

--- a/patterns/behavioural/RAII.md
+++ b/patterns/behavioural/RAII.md
@@ -110,7 +110,7 @@ works just as well.
 
 ## See also
 
-[Finalisation in destructors idiom](../idioms/dtor-finally.md)
+[Finalisation in destructors idiom](../../idioms/dtor-finally.md)
 
 RAII is a common pattern in C++: [cppreference.com](http://en.cppreference.com/w/cpp/language/raii),
 [wikipedia][wikipedia].

--- a/patterns/behavioural/visitor.md
+++ b/patterns/behavioural/visitor.md
@@ -109,5 +109,5 @@ The visitor pattern is a common pattern in most OO languages.
 
 [Wikipedia article](https://en.wikipedia.org/wiki/Visitor_pattern)
 
-The [fold](fold.md) pattern is similar to visitor but produces a new version of
-the visited data structure.
+The [fold](../creational/fold.md) pattern is similar to visitor but produces
+a new version of the visited data structure.

--- a/patterns/creational/fold.md
+++ b/patterns/creational/fold.md
@@ -116,7 +116,7 @@ In other languages, fold is usually used in the sense of Rust's iterators,
 rather than this pattern. Some functional languages have powerful constructs for
 performing flexible maps over data structures.
 
-The [visitor](visitor.md) pattern is closely related to fold. They share the
-concept of walking a data structure performing an operation on each node.
-However, the visitor does not create a new data structure nor consume the old
-one.
+The [visitor](../behavioural/visitor.md) pattern is closely related to fold.
+They share the concept of walking a data structure performing an operation on
+each node. However, the visitor does not create a new data structure nor consume
+the old one.

--- a/patterns/ffi/export.md
+++ b/patterns/ffi/export.md
@@ -249,12 +249,12 @@ with them:
 - [Wrapper Type Consolidation](./wrappers.md) groups multiple Rust types together
   into an opaque "object"
 
-- [FFI Error Passing](../idioms/ffi/errors.md) explains error handling with integer
+- [FFI Error Passing](../../idioms/ffi/errors.md) explains error handling with integer
   codes and sentinel return values (such as `NULL` pointers)
 
-- [Accepting Foreign Strings](../idioms/ffi/accepting-strings.md) allows accepting
+- [Accepting Foreign Strings](../../idioms/ffi/accepting-strings.md) allows accepting
   strings with minimal unsafe code, and is easier to get right than
-  [Passing Strings to FFI](../idioms/ffi/passing-strings.md)
+  [Passing Strings to FFI](../../idioms/ffi/passing-strings.md)
 
 However, not every API can be done this way.
 It is up to the best judgement of the programmer as to who their audience is.


### PR DESCRIPTION
Following on from https://github.com/rust-unofficial/patterns/pull/255 , this pull request fixes several broken links

According to mdbook-linkcheck, **a link is still broken** in [additional_ressources/design-principles.md](https://github.com/rust-unofficial/patterns/blob/a1523995ec3133d36a2106b8578b994a947a15b1/additional_resources/design-principles.md#23) but I do not know what `[not]` could link to.

*sidenote : it is said that mdbook-linkcheck is disabled due to gh-actions but why is it incompatible with gh-actions ?*