### PR TITLE
[idioms/ctor] adds default constructor section

### DIFF
--- a/idioms/ctor.md
+++ b/idioms/ctor.md
@@ -3,34 +3,74 @@
 ## Description
 
 Rust does not have constructors as a language construct. Instead, the
-convention is to use a static `new` method to create an object.
+convention is to use an associated `new` function to create an object:
 
-## Example
-
-```rust,ignore
-// A Rust vector, see liballoc/vec.rs
-pub struct Vec<T> {
-    buf: RawVec<T>,
-    len: usize,
+```rust
+pub struct Second {
+    value: u64
 }
 
-impl<T> Vec<T> {
-    // Constructs a new, empty `Vec<T>`.
-    // Note this is a static method - no self.
-    // This constructor doesn't take any arguments, but some might in order to
-    // properly initialise an object
-    pub fn new() -> Vec<T> {
-        // Create a new Vec with fields properly initialised.
-        Vec {
-            // Note that here we are calling RawVec's constructor.
-            buf: RawVec::new(),
-            len: 0,
-        }
+impl Second {
+    pub fn new(value: u64) -> Self {
+        Self { value }
     }
+}
+
+fn main() {
+    let s = Second::new(42);
 }
 ```
 
+## Default Constructors
+
+Rust supports default constructors with the [`Default`][std-default] trait:
+
+```rust
+pub struct Second {
+    value: u64
+}
+
+impl Default for Second {
+    fn default() -> Self {
+        Self { value: 0 }
+    }
+}
+
+fn main() {
+    let default = Second::default();
+    assert_eq!(default.value, 0);
+}
+```
+
+`Default` can also be derived if all types of all fields implement `Default`,
+like they do with `Second`:
+
+```rust
+#[derive(Default)]
+pub struct Second {
+    value: u64
+}
+
+fn main() {
+    let default = Second::default();
+    assert_eq!(default.value, 0);
+}
+```
+
+**Note:** When implementing `Default` for a type, it is neither required nor
+recommended to also provide an associated `new` function without arguments.
+
+**Hint:** The advantage of implementing or deriving `Default` is that your type
+can now be used where a `Default` implementation is required, most prominently,
+any of the [`*or_default` functions in the standard library][std-or-default].
+
 ## See also
 
-The [builder pattern](../patterns/creational/builder.md) for constructing objects
-where there are multiple configurations.
+- The [default idiom](default.md) for a more in-depth description of the
+  `Default` trait.
+
+- The [builder pattern](../patterns/creational/builder.md) for constructing
+  objects where there are multiple configurations.
+
+[std-default]: https://doc.rust-lang.org/stable/std/default/trait.Default.html
+[std-or-default]: https://doc.rust-lang.org/stable/std/?search=or_default

--- a/idioms/ctor.md
+++ b/idioms/ctor.md
@@ -103,6 +103,8 @@ any of the [`*or_default` functions in the standard library][std-or-default].
 - The [builder pattern](../patterns/creational/builder.md) for constructing
   objects where there are multiple configurations.
 
-[associated function]: https://doc.rust-lang.org/stable/book/ch05-03-method-syntax.html#associated-functions
-[std-default]: https://doc.rust-lang.org/stable/std/default/trait.Default.html
-[std-or-default]: https://doc.rust-lang.org/stable/std/?search=or_default
+- [associated function]: https://doc.rust-lang.org/stable/book/ch05-03-method-syntax.html#associated-functions
+
+- [std-default]: https://doc.rust-lang.org/stable/std/default/trait.Default.html
+
+- [std-or-default]: https://doc.rust-lang.org/stable/std/?search=or_default

--- a/idioms/ctor.md
+++ b/idioms/ctor.md
@@ -84,6 +84,8 @@ any of the [`*or_default` functions in the standard library][std-or-default].
 - The [builder pattern](../patterns/creational/builder.md) for constructing
   objects where there are multiple configurations.
 
-[associated function]: https://doc.rust-lang.org/stable/book/ch05-03-method-syntax.html#associated-functions
-[std-default]: https://doc.rust-lang.org/stable/std/default/trait.Default.html
-[std-or-default]: https://doc.rust-lang.org/stable/std/?search=or_default
+- [associated function]: https://doc.rust-lang.org/stable/book/ch05-03-method-syntax.html#associated-functions
+
+- [std-default]: https://doc.rust-lang.org/stable/std/default/trait.Default.html
+
+- [std-or-default]: https://doc.rust-lang.org/stable/std/?search=or_default

--- a/idioms/ctor.md
+++ b/idioms/ctor.md
@@ -24,6 +24,11 @@ impl Second {
     pub fn new(value: u64) -> Self {
         Self { value }
     }
+
+    /// Returns the value in seconds.
+    pub fn value(&self) -> u64 {
+        self.value
+    }
 }
 ```
 
@@ -42,6 +47,13 @@ Rust supports default constructors with the [`Default`][std-default] trait:
 /// ```
 pub struct Second {
     value: u64
+}
+
+impl Second {
+    /// Returns the value in seconds.
+    pub fn value(&self) -> u64 {
+        self.value
+    }
 }
 
 impl Default for Second {
@@ -66,6 +78,13 @@ like they do with `Second`:
 #[derive(Default)]
 pub struct Second {
     value: u64
+}
+
+impl Second {
+    /// Returns the value in seconds.
+    pub fn value(&self) -> u64 {
+        self.value
+    }
 }
 ```
 

--- a/idioms/ctor.md
+++ b/idioms/ctor.md
@@ -103,8 +103,6 @@ any of the [`*or_default` functions in the standard library][std-or-default].
 - The [builder pattern](../patterns/creational/builder.md) for constructing
   objects where there are multiple configurations.
 
-- [associated function]: https://doc.rust-lang.org/stable/book/ch05-03-method-syntax.html#associated-functions
-
-- [std-default]: https://doc.rust-lang.org/stable/std/default/trait.Default.html
-
-- [std-or-default]: https://doc.rust-lang.org/stable/std/?search=or_default
+[associated function]: https://doc.rust-lang.org/stable/book/ch05-03-method-syntax.html#associated-functions
+[std-default]: https://doc.rust-lang.org/stable/std/default/trait.Default.html
+[std-or-default]: https://doc.rust-lang.org/stable/std/?search=or_default

--- a/idioms/ctor.md
+++ b/idioms/ctor.md
@@ -3,7 +3,7 @@
 ## Description
 
 Rust does not have constructors as a language construct. Instead, the
-convention is to use an associated `new` function to create an object:
+convention is to use an [associated function][] `new` to create an object:
 
 ```rust
 /// Time in seconds.
@@ -68,7 +68,7 @@ pub struct Second {
 ```
 
 **Note:** When implementing `Default` for a type, it is neither required nor
-recommended to also provide an associated `new` function without arguments.
+recommended to also provide an associated function `new` without arguments.
 
 **Hint:** The advantage of implementing or deriving `Default` is that your type
 can now be used where a `Default` implementation is required, most prominently,
@@ -82,5 +82,6 @@ any of the [`*or_default` functions in the standard library][std-or-default].
 - The [builder pattern](../patterns/creational/builder.md) for constructing
   objects where there are multiple configurations.
 
+[associated function]: https://doc.rust-lang.org/stable/book/ch05-03-method-syntax.html#associated-functions
 [std-default]: https://doc.rust-lang.org/stable/std/default/trait.Default.html
 [std-or-default]: https://doc.rust-lang.org/stable/std/?search=or_default

--- a/idioms/ctor.md
+++ b/idioms/ctor.md
@@ -6,6 +6,14 @@ Rust does not have constructors as a language construct. Instead, the
 convention is to use an associated `new` function to create an object:
 
 ```rust
+/// Time in seconds.
+///
+/// # Example
+///
+/// ```
+/// let s = Second::new(42);
+/// assert_eq!(42, s.value());
+/// ```
 pub struct Second {
     value: u64
 }
@@ -15,10 +23,6 @@ impl Second {
         Self { value }
     }
 }
-
-fn main() {
-    let s = Second::new(42);
-}
 ```
 
 ## Default Constructors
@@ -26,6 +30,14 @@ fn main() {
 Rust supports default constructors with the [`Default`][std-default] trait:
 
 ```rust
+/// Time in seconds.
+///
+/// # Example
+///
+/// ```
+/// let s = Second::default();
+/// assert_eq!(0, s.value());
+/// ```
 pub struct Second {
     value: u64
 }
@@ -35,25 +47,23 @@ impl Default for Second {
         Self { value: 0 }
     }
 }
-
-fn main() {
-    let default = Second::default();
-    assert_eq!(default.value, 0);
-}
 ```
 
 `Default` can also be derived if all types of all fields implement `Default`,
 like they do with `Second`:
 
 ```rust
+/// Time in seconds.
+///
+/// # Example
+///
+/// ```
+/// let s = Second::default();
+/// assert_eq!(0, s.value());
+/// ```
 #[derive(Default)]
 pub struct Second {
     value: u64
-}
-
-fn main() {
-    let default = Second::default();
-    assert_eq!(default.value, 0);
 }
 ```
 

--- a/idioms/ctor.md
+++ b/idioms/ctor.md
@@ -19,6 +19,8 @@ pub struct Second {
 }
 
 impl Second {
+    // Constructs a new instance of [`Second`].
+    // Note this is an associated function - no self.
     pub fn new(value: u64) -> Self {
         Self { value }
     }


### PR DESCRIPTION
First, I replaced the `Vec` example with `Second`. This is easier to comprehend compared to the more complex `Vec` example. It's also testable because it doesn't rely on `RawVec`.

--- 

Discussion: https://github.com/rust-unofficial/patterns/discussions/276