### PR TITLE
formatting fixes

### DIFF
--- a/patterns/structural/unsafe-mods.md
+++ b/patterns/structural/unsafe-mods.md
@@ -22,11 +22,8 @@ of the inner module
 ## Examples
 
 * The [`toolshed`](https://docs.rs/toolshed) crate contains its unsafe operations
-  in submodules, presenting a safe interface to users. * `std`s `String` class
-  is a wrapper over `Vec<u8>` with the added invariant that the contents must be
-  valid UTF-8. The operations on `String` ensure this behavior. However, users
-  have the option of using an `unsafe` method to create a `String`, in which case
-  the onus is on them to guarantee the validity of the contents.
+  in submodules, presenting a safe interface to users.
+* `std`'s `String` class is a wrapper over `Vec<u8>` with the added invariant that the contents must be valid UTF-8. The operations on `String` ensure this behavior. However, users have the option of using an `unsafe` method to create a `String`, in which case the onus is on them to guarantee the validity of the contents.
 
 ## See also
 

--- a/patterns/structural/unsafe-mods.md
+++ b/patterns/structural/unsafe-mods.md
@@ -23,8 +23,9 @@ of the inner module
 
 * The [`toolshed`](https://docs.rs/toolshed) crate contains its unsafe operations
   in submodules, presenting a safe interface to users.
-* `std`'s `String` class is a wrapper over `Vec<u8>` with the added invariant that 
-the contents must be valid UTF-8. The operations on `String` ensure this behavior.
+* `std`'s `String` class is a wrapper over `Vec<u8>` with the added invariant
+that the contents must be valid UTF-8. The operations on `String` ensure this
+behavior.
 However, users have the option of using an `unsafe` method to create a `String`,
 in which case the onus is on them to guarantee the validity of the contents.
 

--- a/patterns/structural/unsafe-mods.md
+++ b/patterns/structural/unsafe-mods.md
@@ -23,7 +23,10 @@ of the inner module
 
 * The [`toolshed`](https://docs.rs/toolshed) crate contains its unsafe operations
   in submodules, presenting a safe interface to users.
-* `std`'s `String` class is a wrapper over `Vec<u8>` with the added invariant that the contents must be valid UTF-8. The operations on `String` ensure this behavior. However, users have the option of using an `unsafe` method to create a `String`, in which case the onus is on them to guarantee the validity of the contents.
+* `std`'s `String` class is a wrapper over `Vec<u8>` with the added invariant that 
+the contents must be valid UTF-8. The operations on `String` ensure this behavior.
+However, users have the option of using an `unsafe` method to create a `String`,
+in which case the onus is on them to guarantee the validity of the contents.
 
 ## See also
 


### PR DESCRIPTION
3.3.3 Contain unsafety in small modules
- make list render correctly
- add an apostrophe to "`std`'s"