### PR TITLE
chore: use `Self` instead of the struct name

### DIFF
--- a/patterns/behavioural/newtype.md
+++ b/patterns/behavioural/newtype.md
@@ -35,7 +35,7 @@ impl Bar {
     // Constructor.
     pub fn new(
         //..
-    ) -> Bar {
+    ) -> Self {
 
         //..
 


### PR DESCRIPTION
This PR just fixes a minor but IMO important detail: whenever returning with `new` or `default` using `Self` is preferable