### PR TITLE
fix typo in `patterns/behavioural/strategy.md`

### DIFF
--- a/patterns/behavioural/strategy.md
+++ b/patterns/behavioural/strategy.md
@@ -22,7 +22,7 @@ Imagine we are working on a project that generates reports every month.
 We need the reports to be generated in different formats (strategies), e.g.,
 in `JSON` or `Plain Text` formats.
 But things vary over time, and we don't know what kind of requirement we may get
-in the future. For example, we may need to generate our report in a completly new
+in the future. For example, we may need to generate our report in a completely new
 format, or just modify one of the existing formats.
 
 ## Example


### PR DESCRIPTION
fix typo in `patterns/behavioural/strategy.md`
completly should be completely