### PR TITLE
fix comment in 'Clone to stasify borrow checker'

### DIFF
--- a/anti_patterns/borrow_clone.md
+++ b/anti_patterns/borrow_clone.md
@@ -17,14 +17,14 @@ let mut x = 5;
 // Borrow `x` -- but clone it first
 let y = &mut (x.clone());
 
-// perform some action on the borrow to prevent rust from optimizing this
-//out of existence
-*y += 1;
-
 // without the x.clone() two lines prior, this line would fail on compile as
 // x has been borrowed
 // thanks to x.clone(), x was never borrowed, and this line will run.
 println!("{}", x);
+
+// perform some action on the borrow to prevent rust from optimizing this
+//out of existence
+*y += 1;
 ```
 
 ## Motivation


### PR DESCRIPTION
FIX #290

as what I was mentioned in https://github.com/rust-unofficial/patterns/issues/290#issuecomment-1010204357, due to [NLL](https://rust-lang.github.io/compiler-team/working-groups/nll/), the code runs when there is no .clone() call, so I moved `*y += 1;` to the below of `println!`, to make `y` outlive `&x`