### PR TITLE
Add zh-CN translation to intro

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,6 +1,7 @@
 # Summary
 
 - [Introduction](./intro.md)
+  - [Translation](./translations.md)
 - [Idioms](./idioms/index.md)
   - [Use borrowed types for arguments](./idioms/coercion-arguments.md)
   - [Concatenating Strings with `format!`](./idioms/concat-format.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,7 +1,7 @@
 # Summary
 
 - [Introduction](./intro.md)
-  - [Translation](./translations.md)
+  - [Translations](./translations.md)
 - [Idioms](./idioms/index.md)
   - [Use borrowed types for arguments](./idioms/coercion-arguments.md)
   - [Concatenating Strings with `format!`](./idioms/concat-format.md)

--- a/intro.md
+++ b/intro.md
@@ -1,6 +1,6 @@
-[简体中文翻译](https://fomalhauthmj.github.io/patterns/)
-
 # Introduction
+
+[简体中文翻译](https://fomalhauthmj.github.io/patterns/)
 
 ## Participation
 

--- a/intro.md
+++ b/intro.md
@@ -1,4 +1,4 @@
-[中文翻译](https://fomalhauthmj.github.io/patterns/)
+[简体中文翻译](https://fomalhauthmj.github.io/patterns/)
 
 # Introduction
 

--- a/intro.md
+++ b/intro.md
@@ -1,3 +1,5 @@
+[中文翻译](https://fomalhauthmj.github.io/patterns/)
+
 # Introduction
 
 ## Participation

--- a/intro.md
+++ b/intro.md
@@ -1,7 +1,5 @@
 # Introduction
 
-[简体中文翻译](https://fomalhauthmj.github.io/patterns/)
-
 ## Participation
 
 If you are interested in contributing to this book, check out the

--- a/translations.md
+++ b/translations.md
@@ -1,0 +1,6 @@
+# Translations
+
+- [简体中文](https://fomalhauthmj.github.io/patterns/)
+
+If you want to add a translation, please open an issue in the
+[main repository](https://github.com/rust-unofficial/patterns).


### PR DESCRIPTION
Fix #292 

I added it to intro rather than readme because it's the first page seen in the website, having it in the first place will make it more discoverable.