### PR TITLE
Fix typo

### DIFF
--- a/idioms/option-iter.md
+++ b/idioms/option-iter.md
@@ -50,7 +50,7 @@ iterator which yields exactly one element. It's a more readable alternative to
 `Some(foo).into_iter()`.
 
 * [`Iterator::filter_map`](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.filter_map)
-  is a version of [`Iterator::flat_map`](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.flat_map),
+  is a version of [`Iterator::map`](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.map),
   specialized to mapping functions which return `Option`.
 
 * The [`ref_slice`](https://crates.io/crates/ref_slice) crate provides functions


### PR DESCRIPTION
`Iterator::filter_map` is analogous to `Iterator::map`, not `Iterator::flat_map`