### PR TITLE
Change lints hyphen to underscore

### DIFF
--- a/anti_patterns/deny-warnings.md
+++ b/anti_patterns/deny-warnings.md
@@ -57,35 +57,35 @@ Alternatively, we can specify the lints that we want to `deny` in the code.
 Here is a list of warning lints that is (hopefully) safe to deny (as of Rustc 1.48.0):
 
 ```rust,ignore
-#[deny(bad-style,
-       const-err,
-       dead-code,
-       improper-ctypes,
-       non-shorthand-field-patterns,
-       no-mangle-generic-items,
-       overflowing-literals,
-       path-statements ,
-       patterns-in-fns-without-body,
-       private-in-public,
-       unconditional-recursion,
+#[deny(bad_style,
+       const_err,
+       dead_code,
+       improper_ctypes,
+       non_shorthand_field_patterns,
+       no_mangle_generic_items,
+       overflowing_literals,
+       path_statements,
+       patterns_in_fns_without_body,
+       private_in_public,
+       unconditional_recursion,
        unused,
-       unused-allocation,
-       unused-comparisons,
-       unused-parens,
-       while-true)]
+       unused_allocation,
+       unused_comparisons,
+       unused_parens,
+       while_true)]
 ```
 
 In addition, the following `allow`ed lints may be a good idea to `deny`:
 
 ```rust,ignore
-#[deny(missing-debug-implementations,
-       missing-docs,
-       trivial-casts,
-       trivial-numeric-casts,
-       unused-extern-crates,
-       unused-import-braces,
-       unused-qualifications,
-       unused-results)]
+#[deny(missing_debug_implementations,
+       missing_docs,
+       trivial_casts,
+       trivial_numeric_casts,
+       unused_extern_crates,
+       unused_import_braces,
+       unused_qualifications,
+       unused_results)]
 ```
 
 Some may also want to add `missing-copy-implementations` to their list.

--- a/anti_patterns/deny-warnings.md
+++ b/anti_patterns/deny-warnings.md
@@ -57,7 +57,7 @@ Alternatively, we can specify the lints that we want to `deny` in the code.
 Here is a list of warning lints that is (hopefully) safe to deny (as of Rustc 1.48.0):
 
 ```rust,ignore
-#[deny(bad_style,
+#![deny(bad_style,
        const_err,
        dead_code,
        improper_ctypes,
@@ -78,7 +78,7 @@ Here is a list of warning lints that is (hopefully) safe to deny (as of Rustc 1.
 In addition, the following `allow`ed lints may be a good idea to `deny`:
 
 ```rust,ignore
-#[deny(missing_debug_implementations,
+#![deny(missing_debug_implementations,
        missing_docs,
        trivial_casts,
        trivial_numeric_casts,


### PR DESCRIPTION
`rustc -D nonstandard-style` is a valid syntax; `#[deny(nonstandard_style)]` is also valid. However, `#[deny(nonstandard-style)]` will cause:
```
error: expected one of `(`, `,`, `::`, or `=`, found `-`
  --> example/src/lib.rs:12:19
   |
12 | #[deny(nonstandard-style)]
   |                   ^ expected one of `(`, `,`, `::`, or `=`
```
Which is confusing if someone is trying to copy-paste the code into their own.