### PR TITLE
add site url

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -14,6 +14,7 @@ edition = "2018"
 
 [output.html]
 default-theme = "rust"
+site-url = "/patterns/"
 git-repository-url = "https://github.com/rust-unofficial/patterns"
 git-repository-icon = "fa-github"
 


### PR DESCRIPTION
From the [docs](https://rust-lang.github.io/mdBook/format/configuration/renderers.html#html-renderer-options):

> site-url: The url where the book will be hosted. This is required to ensure navigation links and script/css imports in the 404 file work correctly, even when accessing urls in subdirectories. Defaults to /. If site-url is set, make sure to use document relative links for your assets, meaning they should not start with /.

I just tested our "404" page and it doesn't look good. Maybe after merging this it will work!