### PR TITLE
Remove ref_slice example

### DIFF
--- a/src/patterns/structural/small-crates.md
+++ b/src/patterns/structural/small-crates.md
@@ -33,14 +33,14 @@ We should take advantage of this tooling, and use smaller, more fine-grained dep
 
 ## Examples
 
-The [`ref_slice`](https://crates.io/crates/ref_slice) crate provides functions
-for converting `&T` to `&[T]`.
-
 The [`url`](https://crates.io/crates/url) crate provides tools for working with
 URLs.
 
 The [`num_cpus`](https://crates.io/crates/num_cpus) crate provides a function to
 query the number of CPUs on a machine.
+
+The [`ref_slice`](https://crates.io/crates/ref_slice) crate provides functions
+for converting `&T` to `&[T]`. (Historical example)
 
 ## See also
 

--- a/src/patterns/structural/small-crates.md
+++ b/src/patterns/structural/small-crates.md
@@ -33,6 +33,9 @@ We should take advantage of this tooling, and use smaller, more fine-grained dep
 
 ## Examples
 
+The [`ref_slice`](https://crates.io/crates/ref_slice) crate provides functions
+for converting `&T` to `&[T]`.
+
 The [`url`](https://crates.io/crates/url) crate provides tools for working with
 URLs.
 

--- a/src/patterns/structural/small-crates.md
+++ b/src/patterns/structural/small-crates.md
@@ -33,9 +33,6 @@ We should take advantage of this tooling, and use smaller, more fine-grained dep
 
 ## Examples
 
-The [`ref_slice`](https://crates.io/crates/ref_slice) crate provides functions
-for converting `&T` to `&[T]`.
-
 The [`url`](https://crates.io/crates/url) crate provides tools for working with
 URLs.
 


### PR DESCRIPTION
`ref_slice` is [deprecated](https://lib.rs/crates/ref_slice) and its functionality has been added to the [standard library](https://doc.rust-lang.org/stable/std/slice/fn.from_ref.html). This PR simply removes it as an example from the "Prefer Small Crates" page.

## Other considerations

Would it be useful to add a note redirecting to the `std` implementation, or should the example just be removed entirely?

---

I'm new to contributing here. I've read `CONTRIBUTING.md`, but I'm unable to run `markdownlint` on my current device. If you need me to do this or anything else, please ask!