### PR TITLE
fix: use proper definite, and indefinite articles

### DIFF
--- a/src/idioms/pass-var-to-closure.md
+++ b/src/idioms/pass-var-to-closure.md
@@ -2,12 +2,12 @@
 
 ## Description
 
-By default, closures capture their environment by borrowing. Or you can use
-`move`-closure to move whole environment. However, often you want to move just
-some variables to closure, give it copy of some data, pass it by reference, or
-perform some other transformation.
+By default, closures capture their environment by borrowing. Or you can use a
+`move`-closure to move the whole environment. However, often you want to move
+just some variables to the closure, give it a copy of some data, pass by
+reference, or perform some other transformation.
 
-Use variable rebinding in separate scope for that.
+Use variable rebinding in a separate scope for that.
 
 ## Example
 
@@ -47,13 +47,13 @@ let closure = move || {
 
 ## Advantages
 
-Copied data are grouped together with closure definition, so their purpose is
-more clear, and they will be dropped immediately even if they are not consumed
-by closure.
+Copied data are grouped together with the closure definition, so their purpose 
+is more clear, and they will be dropped immediately even if they are not consumed
+by the closure.
 
-Closure uses same variable names as surrounding code whether data are copied or
-moved.
+The closure uses the same variable names as the surrounding code, whether data
+are copied or moved.
 
 ## Disadvantages
 
-Additional indentation of closure body.
+Additional indentation of the closure body.

--- a/src/idioms/pass-var-to-closure.md
+++ b/src/idioms/pass-var-to-closure.md
@@ -47,9 +47,9 @@ let closure = move || {
 
 ## Advantages
 
-Copied data are grouped together with the closure definition, so their purpose 
-is more clear, and they will be dropped immediately even if they are not consumed
-by the closure.
+Copied data are grouped together with the closure definition, so their purpose
+is more clear, and they will be dropped immediately even if they are not
+consumed by the closure.
 
 The closure uses the same variable names as the surrounding code, whether data
 are copied or moved.


### PR DESCRIPTION
…sure.md

* Minor phrasing updates to keep definite, and indefinite articles to proper grammar. (Good for pedantic readers who get distracted by improper grammar.)
* Not sure if there's a style guide on this point. I find it easier to follow an idea in properly flowing speech.