### PR TITLE
feat: render PDF version of book with `mdbook-pandoc`

### DIFF
--- a/.github/workflows/install-mdbook/action.yml
+++ b/.github/workflows/install-mdbook/action.yml
@@ -31,6 +31,7 @@ runs:
     - name: Install mdbook-pandoc and related dependencies
       run: |
         cargo install mdbook-pandoc --locked --version 0.5.0
+        sudo apt-get update
         sudo apt-get install -y texlive texlive-luatex texlive-lang-cjk librsvg2-bin fonts-noto
         curl -LsSf https://github.com/jgm/pandoc/releases/download/3.1.12.2/pandoc-3.1.12.2-linux-amd64.tar.gz | tar zxf -
         echo "$PWD/pandoc-3.1.12.2/bin" >> $GITHUB_PATH

--- a/.github/workflows/install-mdbook/action.yml
+++ b/.github/workflows/install-mdbook/action.yml
@@ -27,3 +27,11 @@ runs:
     - name: Install i18n-helpers
       run: cargo install mdbook-i18n-helpers --locked --version '${{ steps.mdbook-i18n-helpers-version.outputs.version }}'
       shell: bash
+
+    - name: Install mdbook-pandoc and related dependencies
+      run: |
+        cargo install mdbook-pandoc --locked --version 0.5.0
+        sudo apt-get install -y texlive texlive-luatex texlive-lang-cjk librsvg2-bin fonts-noto
+        curl -LsSf https://github.com/jgm/pandoc/releases/download/3.1.12.2/pandoc-3.1.12.2-linux-amd64.tar.gz | tar zxf -
+        echo "$PWD/pandoc-3.1.12.2/bin" >> $GITHUB_PATH
+      shell: bash

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,9 @@ jobs:
         uses: ./.github/workflows/install-mdbook
 
       - name: Build course in English
-        run: mdbook build -d book
+        run: |
+          mdbook build -d book
+          mv book/html/* book/pandoc/pdf/patterns.pdf book/
 
       # TODO: Activate when first translation is available
       # - name: Build all translations

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,6 +43,7 @@ jobs:
         run: |
           mdbook build -d book
           mv book/html/* book/pandoc/pdf/patterns.pdf book/
+          rm -r book/html book/pandoc
 
       # TODO: Activate when first translation is available
       # - name: Build all translations

--- a/book.toml
+++ b/book.toml
@@ -38,3 +38,20 @@ editable = false
 # Redirects in the form of "old-path" = "new-path", where the new path
 # is relative to the old path.
 "functional/lenses.html" = "optics.html"
+
+[output.pandoc]
+optional = true
+hosted-html = "https://rust-unofficial.github.io/patterns/"
+
+[output.pandoc.profile.pdf]
+output-file = "patterns.pdf"
+pdf-engine = "lualatex"
+
+[output.pandoc.profile.pdf.variables]
+mainfont = "Noto Serif"
+sansfont = "Noto Sans"
+monofont = "Noto Sans Mono"
+mainfontfallback = ["NotoSerifCJKSC:"]
+geometry = ["margin=1.25in"]
+linkcolor = "blue"
+urlcolor = "red"


### PR DESCRIPTION
Uses [mdbook-pandoc](https://github.com/max-heller/mdbook-pandoc) to render a PDF version of the book and publishes it to Github pages.

[Rendered](https://max-heller.com/patterns/patterns.pdf) ([job log](https://github.com/max-heller/patterns/actions/runs/8308838774/job/22739553404#step:5:12))

Related issue #380 