### PR TITLE
fix: line lengths for pdf prints

### DIFF
--- a/src/anti_patterns/borrow_clone.md
+++ b/src/anti_patterns/borrow_clone.md
@@ -17,9 +17,9 @@ let mut x = 5;
 // Borrow `x` -- but clone it first
 let y = &mut (x.clone());
 
-// without the x.clone() two lines prior, this line would fail on compile as
-// x has been borrowed
-// thanks to x.clone(), x was never borrowed, and this line will run.
+// without the x.clone() two lines prior, this line would fail on compile
+// as x has been borrowed thanks to x.clone(), x was never borrowed, and
+// this line will run.
 println!("{x}");
 
 // perform some action on the borrow to prevent rust from optimizing this

--- a/src/functional/optics.md
+++ b/src/functional/optics.md
@@ -28,11 +28,17 @@ implemented by any library which parses a new data format:
 pub trait Deserializer<'de>: Sized {
     type Error: Error;
 
-    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    fn deserialize_any<V>(
+        self,
+        visitor: V
+    ) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>;
 
-    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    fn deserialize_bool<V>(
+        self,
+        visitor: V
+    ) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>;
 
@@ -262,7 +268,8 @@ independent form, it is even possible to have code generation creating the
 `Visitor` associated with type `T`:
 
 ```rust,ignore
-#[derive(Default, Serde)] // the "Serde" derive creates the trait impl block
+// the "Serde" derive creates the trait impl block
+#[derive(Default, Serde)] 
 struct TestStruct {
   a: usize,
   b: String,
@@ -365,11 +372,17 @@ You can see it on the `Deserializer` trait
 pub trait Deserializer<'de>: Sized {
     type Error: Error;
 
-    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    fn deserialize_any<V>(
+        self,
+        visitor: V
+    ) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>;
 
-    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    fn deserialize_bool<V>(
+        self,
+        visitor: V
+    ) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>;
 

--- a/src/idioms/coercion-arguments.md
+++ b/src/idioms/coercion-arguments.md
@@ -107,8 +107,12 @@ fn three_vowels(word: &str) -> bool {
 }
 
 fn main() {
-    let sentence_string =
-        "Once upon a time, there was a friendly curious crab named Ferris".to_string();
+    let sentence_string = "
+        Once upon a time, there was a friendly
+        curious crabnamed Ferris
+    "
+    .to_string();
+
     for word in sentence_string.split(' ') {
         if three_vowels(word) {
             println!("{word} has three consecutive vowels!");

--- a/src/idioms/default.md
+++ b/src/idioms/default.md
@@ -46,7 +46,8 @@ fn main() {
     conf.check = true;
     println!("conf = {conf:#?}");
 
-    // partial initialization with default values, creates the same instance
+    // partial initialization with default values,
+    // creates the same instance
     let conf1 = MyConfiguration {
         check: true,
         ..Default::default()

--- a/src/idioms/ffi/accepting-strings.md
+++ b/src/idioms/ffi/accepting-strings.md
@@ -79,13 +79,17 @@ pub mod unsafe_module {
 
     // other module content
 
-    pub extern "C" fn mylib_log(msg: *const libc::c_char, level: libc::c_int) {
+    pub extern "C" fn mylib_log(
+        msg: *const libc::c_char,
+        level: libc::c_int
+    ) {
         // DO NOT USE THIS CODE.
         // IT IS UGLY, VERBOSE, AND CONTAINS A SUBTLE BUG.
 
         let level: crate::LogLevel = match level { /* ... */ };
 
-        let msg_len = unsafe { /* SAFETY: strlen is what it is, I guess? */
+        let msg_len = unsafe { 
+            // SAFETY: strlen is what it is, I guess?
             libc::strlen(msg)
         };
 

--- a/src/idioms/ffi/errors.md
+++ b/src/idioms/ffi/errors.md
@@ -62,7 +62,8 @@ pub mod c_api {
         ) -> *mut libc::c_char {
 
         let error: &DatabaseError = unsafe {
-            // SAFETY: pointer lifetime is greater than the current stack frame
+            // SAFETY: pointer lifetime is greater than the current
+            // stack frame
             &*e
         };
 
@@ -79,9 +80,10 @@ pub mod c_api {
         };
 
         let c_error = unsafe {
-            // SAFETY: copying error_str to an allocated buffer with a NUL
-            // character at the end
-            let mut malloc: *mut u8 = libc::malloc(error_str.len() + 1) as *mut _;
+            // SAFETY: copying error_str to an allocated buffer
+            // with a NUL character at the end
+            let mut malloc: *mut u8 =
+                libc::malloc(error_str.len() + 1) as *mut _;
 
             if malloc.is_null() {
                 return std::ptr::null_mut();

--- a/src/idioms/ffi/passing-strings.md
+++ b/src/idioms/ffi/passing-strings.md
@@ -32,7 +32,10 @@ pub mod unsafe_module {
 
     extern "C" {
         fn seterr(message: *const libc::c_char);
-        fn geterr(buffer: *mut libc::c_char, size: libc::c_int) -> libc::c_int;
+        fn geterr(
+            buffer: *mut libc::c_char,
+            size: libc::c_int,
+        ) -> libc::c_int;
     }
 
     fn report_error_to_ffi<S: Into<String>>(
@@ -41,8 +44,8 @@ pub mod unsafe_module {
         let c_err = std::ffi::CString::new(err.into())?;
 
         unsafe {
-            // SAFETY: calling an FFI whose documentation says the pointer is
-            // const, so no modification should occur
+            // SAFETY: calling an FFI whose documentation says the
+            // pointer is const, so no modification should occur
             seterr(c_err.as_ptr());
         }
 
@@ -81,7 +84,9 @@ pub mod unsafe_module {
 
     // other module content
 
-    fn report_error<S: Into<String>>(err: S) -> Result<(), std::ffi::NulError> {
+    fn report_error<S: Into<String>>(
+        err: S
+    ) -> Result<(), std::ffi::NulError> {
         unsafe {
             // SAFETY: whoops, this contains a dangling pointer!
             seterr(std::ffi::CString::new(err.into())?.as_ptr());

--- a/src/idioms/mem-replace.md
+++ b/src/idioms/mem-replace.md
@@ -44,8 +44,9 @@ enum MultiVariateEnum {
 fn swizzle(e: &mut MultiVariateEnum) {
     use MultiVariateEnum::*;
     *e = match e {
-        // Ownership rules do not allow taking `name` by value, but we cannot
-        // take the value out of a mutable reference, unless we replace it:
+        // Ownership rules do not allow taking `name` by value, but we
+        // cannot take the value out of a mutable reference, unless we
+        // replace it:
         A { name } => B { name: mem::take(name) },
         B { name } => A { name: mem::take(name) },
         C => D,

--- a/src/idioms/priv-extend.md
+++ b/src/idioms/priv-extend.md
@@ -76,8 +76,8 @@ warning.
 ```rust
 pub struct S {
     pub a: i32,
-    // Because `b` is private, you cannot match on `S` without using `..` and `S`
-    //  cannot be directly instantiated or matched against
+    // Because `b` is private, you cannot match on `S` without using
+    // `..` and `S` cannot be directly instantiated or matched against
     _b: ()
 }
 ```

--- a/src/idioms/return-consumed-arg-on-error.md
+++ b/src/idioms/return-consumed-arg-on-error.md
@@ -12,7 +12,11 @@ pub fn send(value: String) -> Result<(), SendError> {
     println!("using {value} in a meaningful way");
     // Simulate non-deterministic fallible action.
     use std::time::SystemTime;
-    let period = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap();
+
+    let period = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap();
+
     if period.subsec_nanos() % 2 == 1 {
         Ok(())
     } else {
@@ -23,7 +27,8 @@ pub fn send(value: String) -> Result<(), SendError> {
 pub struct SendError(String);
 
 fn main() {
-    let mut value = "imagine this is very long string".to_string();
+    let mut value = 
+        "imagine this is very long string".to_string();
 
     let success = 's: {
         // Try to send value two times.

--- a/src/patterns/behavioural/RAII.md
+++ b/src/patterns/behavioural/RAII.md
@@ -51,7 +51,8 @@ impl<'a, T> Drop for MutexGuard<'a, T> {
     }
 }
 
-// Implementing Deref means we can treat MutexGuard like a pointer to T.
+// Implementing Deref means we can treat MutexGuard like a
+// pointer to T.
 impl<'a, T> Deref for MutexGuard<'a, T> {
     type Target = T;
 
@@ -63,10 +64,11 @@ impl<'a, T> Deref for MutexGuard<'a, T> {
 fn baz(x: Mutex<Foo>) {
     let xx = x.lock();
     xx.foo(); // foo is a method on Foo.
-    // The borrow checker ensures we can't store a reference to the underlying
-    // Foo which will outlive the guard xx.
+    // The borrow checker ensures we can't store a reference to the
+    // underlying Foo which will outlive the guard xx.
 
-    // x is unlocked when we exit this function and xx's destructor is executed.
+    // x is unlocked when we exit this function and xx's destructor
+    // is executed.
 }
 ```
 

--- a/src/patterns/behavioural/command.md
+++ b/src/patterns/behavioural/command.md
@@ -140,9 +140,15 @@ fn remove_field() -> String {
 
 fn main() {
     let mut schema = Schema::new();
-    schema.add_migration(|| "create table".to_string(), || "drop table".to_string());
+    schema.add_migration(
+        || "create table".to_string(),
+        || "drop table".to_string()
+    );
+
     schema.add_migration(add_field, remove_field);
+
     assert_eq!(vec!["create table", "add field"], schema.execute());
+    
     assert_eq!(vec!["remove field", "drop table"], schema.rollback());
 }
 ```

--- a/src/patterns/behavioural/strategy.md
+++ b/src/patterns/behavioural/strategy.md
@@ -45,7 +45,8 @@ trait Formatter {
 struct Report;
 
 impl Report {
-    // Write should be used but we kept it as String to ignore error handling
+    // Write should be used but we kept it as String to ignore
+    // error handling
     fn generate<T: Formatter>(g: T, s: &mut String) {
         // backend operations...
         let mut data = HashMap::new();

--- a/src/patterns/behavioural/visitor.md
+++ b/src/patterns/behavioural/visitor.md
@@ -45,7 +45,8 @@ mod visit {
 use visit::*;
 use ast::*;
 
-// An example concrete implementation - walks the AST interpreting it as code.
+// An example concrete implementation - walks the AST interpreting
+// it as code.
 struct Interpreter;
 impl Visitor<i64> for Interpreter {
     fn visit_name(&mut self, n: &Name) -> i64 { panic!() }
@@ -59,8 +60,12 @@ impl Visitor<i64> for Interpreter {
     fn visit_expr(&mut self, e: &Expr) -> i64 {
         match *e {
             Expr::IntLit(n) => n,
-            Expr::Add(ref lhs, ref rhs) => self.visit_expr(lhs) + self.visit_expr(rhs),
-            Expr::Sub(ref lhs, ref rhs) => self.visit_expr(lhs) - self.visit_expr(rhs),
+            Expr::Add(ref lhs, ref rhs) => { 
+                self.visit_expr(lhs) + self.visit_expr(rhs)
+            }
+            Expr::Sub(ref lhs, ref rhs) => {
+                self.visit_expr(lhs) - self.visit_expr(rhs)
+            }
         }
     }
 }

--- a/src/patterns/creational/builder.md
+++ b/src/patterns/creational/builder.md
@@ -35,17 +35,18 @@ impl FooBuilder {
     }
 
     pub fn name(mut self, bar: String) -> FooBuilder {
-        // Set the name on the builder itself, and return the builder by value.
+        // Set the name on the builder itself, and return the
+        // builder by value.
         self.bar = bar;
         self
     }
 
-    // If we can get away with not consuming the Builder here, that is an
-    // advantage. It means we can use the FooBuilder as a template for constructing
-    // many Foos.
+    // If we can get away with not consuming the Builder here,
+    // that is an advantage. It means we can use the FooBuilder
+    // as a template for constructing many `Foo`s.
     pub fn build(self) -> Foo {
-        // Create a Foo from the FooBuilder, applying all settings in FooBuilder
-        // to Foo.
+        // Create a Foo from the FooBuilder, applying all
+        // settings in FooBuilder to Foo.
         Foo { bar: self.bar }
     }
 }
@@ -55,7 +56,11 @@ fn builder_test() {
     let foo = Foo {
         bar: String::from("Y"),
     };
-    let foo_from_builder: Foo = FooBuilder::new().name(String::from("Y")).build();
+    
+    let foo_from_builder: Foo = FooBuilder::new()
+        .name(String::from("Y"))
+        .build();
+
     assert_eq!(foo, foo_from_builder);
 }
 ```

--- a/src/patterns/creational/fold.md
+++ b/src/patterns/creational/fold.md
@@ -35,14 +35,26 @@ mod fold {
     use ast::*;
 
     pub trait Folder {
-        // A leaf node just returns the node itself. In some cases, we can do this
-        // to inner nodes too.
+        // A leaf node just returns the node itself.
+        // In some cases, we can do this to inner
+        // nodes too.
         fn fold_name(&mut self, n: Box<Name>) -> Box<Name> { n }
         // Create a new inner node by folding its children.
         fn fold_stmt(&mut self, s: Box<Stmt>) -> Box<Stmt> {
             match *s {
-                Stmt::Expr(e) => Box::new(Stmt::Expr(self.fold_expr(e))),
-                Stmt::Let(n, e) => Box::new(Stmt::Let(self.fold_name(n), self.fold_expr(e))),
+                Stmt::Expr(e) => {
+                    Box::new(
+                        Stmt::Expr(self.fold_expr(e))
+                    )
+                }
+                Stmt::Let(n, e) => {
+                    Box::new(
+                        Stmt::Let(
+                            self.fold_name(n),
+                            self.fold_expr(e)
+                        )
+                    )
+                }
             }
         }
         fn fold_expr(&mut self, e: Box<Expr>) -> Box<Expr> { ... }

--- a/src/patterns/ffi/export.md
+++ b/src/patterns/ffi/export.md
@@ -152,18 +152,21 @@ consider what a straightforward API translation would look like:
 ```rust,ignore
 #[no_mangle]
 pub extern "C" fn dbm_iter_new(owner: *const Dbm) -> *mut DbmKeysIter {
-    // THIS API IS A BAD IDEA! For real applications, use object-based design instead.
+    // THIS API IS A BAD IDEA! For real applications,
+    // use object-based design instead.
 }
 #[no_mangle]
 pub extern "C" fn dbm_iter_next(
     iter: *mut DbmKeysIter,
     key_out: *const datum
 ) -> libc::c_int {
-    // THIS API IS A BAD IDEA! For real applications, use object-based design instead.
+    // THIS API IS A BAD IDEA! For real applications,
+    // use object-based design instead.
 }
 #[no_mangle]
 pub extern "C" fn dbm_iter_del(*mut DbmKeysIter) {
-    // THIS API IS A BAD IDEA! For real applications, use object-based design instead.
+    // THIS API IS A BAD IDEA! For real applications,
+    // use object-based design instead.
 }
 ```
 
@@ -186,13 +189,16 @@ int count_key_sizes(DBM *db) {
     }
 
     int l;
-    while ((l = dbm_iter_next(owner, &key)) >= 0) { // an error is indicated by -1
+
+    // an error is indicated by -1, and end of iteration by 0
+    while ((l = dbm_iter_next(owner, &key)) >= 0) { 
         free(key.dptr);
         len += key.dsize;
         if (l == 0) { // end of the iterator
             dbm_close(owner);
         }
     }
+    
     if l >= 0 {
         return -1;
     } else {

--- a/src/patterns/ffi/wrappers.md
+++ b/src/patterns/ffi/wrappers.md
@@ -118,9 +118,11 @@ pub mod unsafe_module {
         key: datum,
         value: datum) -> libc::c_int {
 
-        // DO NOT USE THIS CODE. IT IS UNSAFE TO DEMONSTRATE A PROLBEM.
+        // DO NOT USE THIS CODE. IT IS UNSAFE TO DEMONSTRATE
+        // A PROLBEM.
 
-        let myset: &mut MySet = unsafe { // SAFETY: whoops, UB occurs in here!
+        // SAFETY: whoops, UB occurs in here!
+        let myset: &mut MySet = unsafe { 
             &mut (*myset).myset
         };
 

--- a/src/patterns/structural/compose-structs.md
+++ b/src/patterns/structural/compose-structs.md
@@ -38,9 +38,13 @@ fn main() {
     };
 
     let connection_string = &mut db.connection_string;
-    print_database(&db);  // Immutable borrow of `db` happens here
-    // *connection_string = "new string".to_string();  // Mutable borrow is used
-                                                       // here
+
+    // Immutable borrow of `db` happens here
+    print_database(&db);
+
+    // Mutable borrow would be used here
+    // This would cause a compile error           
+    // *connection_string = "new string".to_string();  
 }
 ```
 
@@ -48,7 +52,11 @@ We can apply this design pattern and refactor `Database` into three smaller
 structs, thus solving the borrow checking issue:
 
 ```rust
-// Database is now composed of three structs - ConnectionString, Timeout and PoolSize.
+// Database is now composed of three structs
+// - ConnectionString,
+// - Timeout and
+// - PoolSize.
+//
 // Let's decompose it into smaller structs
 #[derive(Debug, Clone)]
 struct ConnectionString(String);


### PR DESCRIPTION
A bit premature, didn't know that there is a fix in the pipeline. So fixed the line lengths for now. Will wait to see, if new release fixes it.

CC: https://github.com/max-heller/mdbook-pandoc/pull/72