### PR TITLE
fix(PDF): install `texlive-latex-extra` to get `fvextra` to enable line wrapping in code blocks

### DIFF
--- a/.github/workflows/install-mdbook/action.yml
+++ b/.github/workflows/install-mdbook/action.yml
@@ -34,7 +34,7 @@ runs:
     - name: Install mdbook-pandoc and related dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y texlive texlive-luatex texlive-lang-cjk librsvg2-bin fonts-noto
+        sudo apt-get install -y texlive texlive-latex-extra texlive-luatex texlive-lang-cjk librsvg2-bin fonts-noto
         curl -LsSf https://github.com/jgm/pandoc/releases/download/3.1.12.2/pandoc-3.1.12.2-linux-amd64.tar.gz | tar zxf -
         echo "$PWD/pandoc-3.1.12.2/bin" >> $GITHUB_PATH
       shell: bash


### PR DESCRIPTION
[Rendered](https://max-heller.com/patterns/patterns.pdf)

Related to #395 