### PR TITLE
fix: typo "is is" to "is" in src/idioms/ffi/accepting-strings.md

### DIFF
--- a/src/idioms/ffi/accepting-strings.md
+++ b/src/idioms/ffi/accepting-strings.md
@@ -64,7 +64,7 @@ pub mod unsafe_module {
 
 ## Advantages
 
-The example is is written to ensure that:
+The example is written to ensure that:
 
 1. The `unsafe` block is as small as possible.
 2. The pointer with an "untracked" lifetime becomes a "tracked" shared reference


### PR DESCRIPTION
very simple typo fix from:
`The example is is written to ensure that:`
into:
`The example is written to ensure that:`

This can be found in the first line under the Advantages category in `src/idioms/ffi/accepting-strings.md`.

*(now i can rest knowing this typo will not curse the readers with irreparable trauma ;) )*
