### PR TITLE
chore(destructors): add clarification to code

### DIFF
--- a/src/idioms/dtor-finally.md
+++ b/src/idioms/dtor-finally.md
@@ -10,7 +10,7 @@ be used to run code that must be run before exit.
 
 ```rust,ignore
 fn baz() -> Result<(), ()> {
-// some code
+    // some code
 }
 
 fn bar() -> Result<(), ()> {

--- a/src/idioms/dtor-finally.md
+++ b/src/idioms/dtor-finally.md
@@ -9,6 +9,10 @@ be used to run code that must be run before exit.
 ## Example
 
 ```rust,ignore
+fn baz() -> Result<(), ()> {
+// some code
+}
+
 fn bar() -> Result<(), ()> {
     // These don't need to be defined inside the function.
     struct Foo;


### PR DESCRIPTION
Added clarification to the code example regarding the baz() function. The baz() function is explicitly added to the code example.