### PR TITLE
Update send_request function signature to return Result

### DIFF
--- a/src/idioms/rustdoc-init.md
+++ b/src/idioms/rustdoc-init.md
@@ -64,7 +64,7 @@ impl Connection {
     /// assert!(response.is_ok());
     /// # }
     /// ```
-    fn send_request(&self, request: Request) {
+    fn send_request(&self, request: Request) -> Result<Status, SendErr> {
         // ...
     }
 }


### PR DESCRIPTION
In the Motivation `send_request` has a return type, in the example it does not. This PR fixes this :)