### PR TITLE
Fixed compilation errors and warnings emited by example visitor implemention

### DIFF
--- a/src/patterns/behavioural/visitor.md
+++ b/src/patterns/behavioural/visitor.md
@@ -48,7 +48,7 @@ use visit::*;
 // An example concrete implementation - walks the AST interpreting it as code.
 struct Interpreter;
 impl Visitor<i64> for Interpreter {
-    fn visit_name(&mut self, n: &Name) -> i64 {
+    fn visit_name(&mut self, _n: &Name) -> i64 {
         panic!()
     }
     fn visit_stmt(&mut self, s: &Stmt) -> i64 {

--- a/src/patterns/behavioural/visitor.md
+++ b/src/patterns/behavioural/visitor.md
@@ -33,7 +33,7 @@ mod ast {
 
 // The abstract visitor
 mod visit {
-    use ast::*;
+    use crate::ast::*;
 
     pub trait Visitor<T> {
         fn visit_name(&mut self, n: &Name) -> T;


### PR DESCRIPTION
Solved the problems described in the linked issue https://github.com/rust-unofficial/patterns/issues/481